### PR TITLE
add zope.interface requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     certbot>=0.34.0
     setuptools
     requests
+    zope.interface
     sh-nic-api>=1.0.3
 
 [options.packages.find]


### PR DESCRIPTION
This library is required by your code and certbot/certbot container doesn't include zope.interface